### PR TITLE
Set runner version in ci pipeline and update github tag action to 1.34.0

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -9,20 +9,20 @@ on:
 jobs:
   test-base-activity:
     name: Test base activity
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Run the tests on the base activity
-      id: test-activity-base
-      run: |
-        docker build -f Dockerfile-activity-base-test -t activity-base-test .
-        docker run activity-base-test
+      - name: Run the tests on the base activity
+        id: test-activity-base
+        run: |
+          docker build -f Dockerfile-activity-base-test -t activity-base-test .
+          docker run activity-base-test
 
   test-base-transformer:
     name: Test base transformer
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -35,15 +35,15 @@ jobs:
 
   release:
     name: Create new release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.ref == 'refs/heads/main'
-    needs: [test-base-activity, test-base-transformer]
+    needs: [ test-base-activity, test-base-transformer ]
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Bump version and push tag
-      id: push-tag
-      uses: anothrNick/github-tag-action@1.26.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        WITH_V: true
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Bump version and push tag
+        id: push-tag
+        uses: anothrNick/github-tag-action@1.34.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: true


### PR DESCRIPTION
1.26.0 does not tag the branch main by default.