### PR TITLE
Include the VERSION in the manifest due to setup issue

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 include atmosphere/activity/*_logging.yaml
-
+include atmosphere/VERSION


### PR DESCRIPTION
Add this in so it actually installs the VERSION file too, as well as these old logging files in case we re-enable that (to check with @gusmith )

https://github.com/ambiata/atmospherex-demo-sushi/pull/48/checks?check_run_id=1951153971

```python
  File "/usr/local/lib/python3.8/site-packages/atmosphere/_version.py", line 6, in get_version
    with open(current_dir / "VERSION") as version_file:
FileNotFoundError: [Errno 2] No such file or directory: '/usr/local/lib/python3.8/site-packages/atmosphere/VERSION'
Error: Process completed with exit code 1.
```