### PR TITLE
[#minor] fix 204 response

### DIFF
--- a/atmosphere/custom_activity/api/endpoints.py
+++ b/atmosphere/custom_activity/api/endpoints.py
@@ -1,9 +1,9 @@
 import logging
 
+from fastapi import Response
 from starlette.status import HTTP_204_NO_CONTENT
 
 from atmosphere._version import get_version
-
 from ..base_class import BaseActivityCustomCode
 from ..pydantic_models import (AppliedExclusionConditionsResponse,
                                ComputeRewardResponse,
@@ -31,12 +31,14 @@ class Endpoints:
             self.module.validate_prediction_request,
             methods=["POST"],
             status_code=HTTP_204_NO_CONTENT,
+            response_class=Response
         )
         self.router.add_api_route(
             "/validate-outcome-request",
             self.module.validate_outcome_request,
             methods=["POST"],
             status_code=HTTP_204_NO_CONTENT,
+            response_class=Response
         )
         self.router.add_api_route(
             "/compute-reward",

--- a/atmosphere/custom_activity/api/endpoints.py
+++ b/atmosphere/custom_activity/api/endpoints.py
@@ -4,6 +4,7 @@ from fastapi import Response
 from starlette.status import HTTP_204_NO_CONTENT
 
 from atmosphere._version import get_version
+
 from ..base_class import BaseActivityCustomCode
 from ..pydantic_models import (AppliedExclusionConditionsResponse,
                                ComputeRewardResponse,
@@ -31,14 +32,14 @@ class Endpoints:
             self.module.validate_prediction_request,
             methods=["POST"],
             status_code=HTTP_204_NO_CONTENT,
-            response_class=Response
+            response_class=Response,
         )
         self.router.add_api_route(
             "/validate-outcome-request",
             self.module.validate_outcome_request,
             methods=["POST"],
             status_code=HTTP_204_NO_CONTENT,
-            response_class=Response
+            response_class=Response,
         )
         self.router.add_api_route(
             "/compute-reward",

--- a/tests/custom_activity/api/test_endpoints.py
+++ b/tests/custom_activity/api/test_endpoints.py
@@ -4,6 +4,7 @@ from fastapi.testclient import TestClient
 
 from atmosphere.custom_activity.pydantic_models import (ComputeRewardResponse,
                                                         Versions)
+
 from ..activity_for_tests import ActivityCustomCodeForTest, ExpectedModel
 
 
@@ -59,8 +60,8 @@ def test_versions(client: TestClient) -> None:
     compute_reward_response = Versions.parse_obj(response.json())
     assert len(compute_reward_response.base_version) > 0
     assert (
-            compute_reward_response.module_version
-            == ActivityCustomCodeForTest.expected_module_version
+        compute_reward_response.module_version
+        == ActivityCustomCodeForTest.expected_module_version
     )
 
 

--- a/tests/custom_activity/api/test_endpoints.py
+++ b/tests/custom_activity/api/test_endpoints.py
@@ -4,7 +4,6 @@ from fastapi.testclient import TestClient
 
 from atmosphere.custom_activity.pydantic_models import (ComputeRewardResponse,
                                                         Versions)
-
 from ..activity_for_tests import ActivityCustomCodeForTest, ExpectedModel
 
 
@@ -15,11 +14,19 @@ class Example:
     good_prediction: ExpectedModel = ExpectedModel(a=a, b=b)
 
 
+def _assert_204(response):
+    assert response.status_code == 204
+    assert "Content-Length" not in response.headers
+    assert "content-length" not in response.headers
+    assert "content-type" not in response.headers
+    assert "Content-Type" not in response.headers
+
+
 def test_validate_prediction(client: TestClient) -> None:
     response = client.post(
         "/validate-prediction-request", json=Example.good_prediction.dict()
     )
-    assert response.status_code == 204
+    _assert_204(response)
 
 
 def test_validate_prediction_not_valid(client: TestClient) -> None:
@@ -30,7 +37,7 @@ def test_validate_outcome(client: TestClient) -> None:
     response = client.post(
         "/validate-outcome-request", json=Example.good_prediction.dict()
     )
-    assert response.status_code == 204
+    _assert_204(response)
 
 
 def test_validate_outcome_not_valid(client: TestClient) -> None:
@@ -52,8 +59,8 @@ def test_versions(client: TestClient) -> None:
     compute_reward_response = Versions.parse_obj(response.json())
     assert len(compute_reward_response.base_version) > 0
     assert (
-        compute_reward_response.module_version
-        == ActivityCustomCodeForTest.expected_module_version
+            compute_reward_response.module_version
+            == ActivityCustomCodeForTest.expected_module_version
     )
 
 


### PR DESCRIPTION
Without the change, when a method was returning `None`, the endpoint would return a response with a status code equal to 204, but with some content (the string "null" of size 4).
Way inspired by https://github.com/tiangolo/fastapi/issues/717#issuecomment-753360668 . In this issue, they also describe the reason why it was happening: by default FastApi would use a JsonResponse which would normally serialise `None` to the json `null`. 
I tried the tests implemented in this PR without the code change, and they failed (as `content-length` and `content-type` were in the headers). Wit the change they pass.