### PR TITLE
[#minor] Add the expected keys in the expected logs json object 

### DIFF
--- a/atmosphere/custom_activity/base_class.py
+++ b/atmosphere/custom_activity/base_class.py
@@ -95,9 +95,7 @@ class BaseActivityCustomCode(ABC):
         """
         return AppliedExclusionConditionsResponse(applied_exclusion_conditions=[])
 
-    def get_bias_attribute_configs(
-        self
-    ) -> BiasAttributeConfigListResponse:
+    def get_bias_attribute_configs(self) -> BiasAttributeConfigListResponse:
         """
         Define the bias attribute configs, these decide which attributes may be
         used by atmospherex as bias attributes

--- a/atmosphere/custom_activity/pydantic_models.py
+++ b/atmosphere/custom_activity/pydantic_models.py
@@ -87,7 +87,9 @@ class InferenceInfo(BaseModel):
 
 class Logs(BaseModel):
     filtered_action_pool: dict
-    inference: dict = Field({}, title="Inference logs", description="Logs received from inference endpoints")
+    inference: dict = Field(
+        {}, title="Inference logs", description="Logs received from inference endpoints"
+    )
 
 
 class DefaultPredictionResponse(BaseModel):

--- a/atmosphere/custom_activity/pydantic_models.py
+++ b/atmosphere/custom_activity/pydantic_models.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import List, Optional
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class BaseModelForbiddingExtraFields(BaseModel):
@@ -85,11 +85,16 @@ class InferenceInfo(BaseModel):
     allocation: AllocationLog
 
 
+class Logs(BaseModel):
+    filtered_action_pool: dict
+    inference: dict = Field({}, title="Inference logs", description="Logs received from inference endpoints")
+
+
 class DefaultPredictionResponse(BaseModel):
     atmosphere_call_uuid: UUID
     info: InferenceInfo
     predictions: dict
-    logs: dict
+    logs: Logs
 
 
 class ExclusionRuleCondition(BaseModel):

--- a/tests/custom_activity/test_server.py
+++ b/tests/custom_activity/test_server.py
@@ -45,7 +45,10 @@ default_prediction_example = {
         "allocation": {"current_phase": None, "allocation_random_number": None},
     },
     "predictions": {"name": "baseline"},
-    "logs": {},
+    "logs": {
+        "inference": {},
+        "filtered_action_pool": {}
+    },
 }
 
 


### PR DESCRIPTION
In the `DefaultPredictionResponse`

Related issue in atmosphereX: https://github.com/ambiata/atmospherex/issues/206 which is asking for documentation about this payload.