### PR TITLE
[#major] First changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## v2.0.0
+
+The custom activity `DefaultPredictionResponse` model has been updated: the `logs` object is now a Pydantic model
+instead of a `dict`. We can thus specify the expected keys in it.


### PR DESCRIPTION
I will delete the tag 1.4.0 as I realised it is a breaking change compared to the previous version: to use the new version, you MUST change code (if you were using the logs object in `DefaultPredictionResponse` in the custom activity).