### PR TITLE
[#major] Test python 3.7, 3.8 and 3.9

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
       - name: Checkout

--- a/tests/custom_activity/test_server.py
+++ b/tests/custom_activity/test_server.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 from pytest import fixture
@@ -69,7 +68,6 @@ def fixture_test_client() -> TestClient:
     return TestClient(server)
 
 
-@patch("importlib.metadata", lambda: "foo")
 def test_entrypoint_test(client: TestClient):
     resp = client.get("/versions")
     assert resp.status_code == 200


### PR DESCRIPTION
The main reason for this PR is actually to increase major version which was not done on the previous PR.
I want thus to delete the tag `3.1.0` which should have been a major increase.
The only "small" change I could find (and useful) was to test the library for python 3.7, 3.8 and 3.9, knowing that 3.7 is used by TLAU.