### PR TITLE
[#major] test the tag bump

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -38,27 +38,6 @@ jobs:
       - name: Run the test
         run: |
           ./scripts/test.sh
-
-  testouille:
-    name: testouille
-    runs-on: ubuntu-20.04
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: '0'
-
-    - name: git config
-      run: |
-        git config --global --add safe.directory /github/workspace
-
-    - name: Dry bump version and push tag
-      id: dry-bump-tag
-      uses: anothrNick/github-tag-action@1.36.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        WITH_V: true
-        DRY_RUN: true
   
   tag:
     name: Create new release
@@ -71,9 +50,15 @@ jobs:
       with:
         fetch-depth: '0'
 
+    # When https://github.com/anothrNick/github-tag-action/issues/150 will be closed, we should be able to use
+    # newer version of anothrNick/github-tag-action (post 1.39.0) which should include this step.
+    - name: git config
+      run: |
+        git config --global --add safe.directory /github/workspace
+
     - name: Dry bump version and push tag
       id: dry-bump-tag
-      uses: anothrNick/github-tag-action@1.39.0
+      uses: anothrNick/github-tag-action@1.36.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WITH_V: true
@@ -93,7 +78,7 @@ jobs:
 
     - name: Push tag
       id: push-tag
-      uses: anothrNick/github-tag-action@1.39.0
+      uses: anothrNick/github-tag-action@1.36.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WITH_V: true

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -48,9 +48,13 @@ jobs:
       with:
         fetch-depth: '0'
 
+    - name: git config
+      run: |
+        git config --global --add safe.directory /github/workspace
+
     - name: Dry bump version and push tag
       id: dry-bump-tag
-      uses: anothrNick/github-tag-action@1.39.0
+      uses: anothrNick/github-tag-action@1.36.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WITH_V: true

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -38,6 +38,23 @@ jobs:
       - name: Run the test
         run: |
           ./scripts/test.sh
+
+  testouille:
+    name: testouille
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
+
+    - name: Dry bump version and push tag
+      id: dry-bump-tag
+      uses: anothrNick/github-tag-action@1.39.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        WITH_V: true
+        DRY_RUN: true
   
   tag:
     name: Create new release
@@ -47,6 +64,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
 
     - name: Dry bump version and push tag
       id: dry-bump-tag


### PR DESCRIPTION
Nasty bug.
But this PR should make it work: one extra step and revert to and older version of the action. We can see that it will try to bump well to the newest major version in https://github.com/ambiata/atmosphere-python-sdk/runs/6072911218?check_suite_focus=true (where I add an extra stage running a dry-run).